### PR TITLE
skip postinstall chown on Windows systems

### DIFF
--- a/index.js
+++ b/index.js
@@ -335,6 +335,8 @@ pip3 install -U virtualenv && ${runPy}
   postinstall(dir, libDir, funcRuntime) {
     if (!this.dockerizedPip) {
       return BbPromise.resolve()
+    } else if (os.platform() === 'win32') {
+        return BbPromise.resolve()
     }
     const cmd = (() => {
       const userInfo = os.userInfo();


### PR DESCRIPTION
When running the current library version on Windows the process fails with an `chown: invalid option -- '1'` error messages.
This is because `os.userInfo()` returns -1 for uid & gid on Windows systems (https://nodejs.org/api/os.html#os_os_userinfo_options).

Skipping the postinstall step on Windows seems to be a good option for now.
On my system it's running fine.